### PR TITLE
ENH: Add ARM-based builds for Linux and macOS

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -18,6 +18,16 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,26 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma10
+expat:
+- '2'
+freetype:
+- '2'
+pcre:
+- '8'
+poppler:
+- '26.07'
+target_platform:
+- linux-aarch64
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,30 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '21'
+expat:
+- '2'
+freetype:
+- '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pcre:
+- '8'
+poppler:
+- '26.07'
+target_platform:
+- osx-arm64
+zlib:
+- '1'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -34,6 +34,18 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
+          - CONFIG: linux_aarch64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-24.04-arm']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,6 +57,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -96,6 +96,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     rattler-build debug shell
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+    fi
+
     rattler-build build --recipe ./recipe \
         -m ./.ci_support/${CONFIG}.yaml \
         ${EXTRA_CB_OPTIONS:-} \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pdfgrep-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8631&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pdfgrep-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,12 @@
+conda_build:
+  error_overlinking: true
+conda_build_tool: rattler-build
 conda_forge_output_validation: true
+conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main
-conda_build:
-  pkg_format: '2'
-conda_install_tool: pixi
-conda_build_tool: rattler-build
+provider:
+  linux_aarch64: default
+  osx_arm64: default
+test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ version = "2026.8.9"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/pdfgrep-feedstock"
 authors = ["@conda-forge/pdfgrep"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [tasks.build-locally]
@@ -46,6 +46,15 @@ description = "Build pdfgrep-feedstock with variant linux_64_ directly (without 
 [feature.build.tasks."inspect-linux_64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
 description = "List contents of pdfgrep-feedstock packages built for variant linux_64_"
+[feature.build.tasks."build-linux_aarch64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_.yaml"
+description = "Build pdfgrep-feedstock with variant linux_aarch64_ directly (without setup scripts)"
+[feature.build.tasks."debug-linux_aarch64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/linux_aarch64_.yaml"
+description = "Build pdfgrep-feedstock with variant linux_aarch64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-linux_aarch64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_.yaml"
+description = "List contents of pdfgrep-feedstock packages built for variant linux_aarch64_"
 [feature.build.tasks."build-osx_64_"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_.yaml"
 description = "Build pdfgrep-feedstock with variant osx_64_ directly (without setup scripts)"
@@ -55,6 +64,15 @@ description = "Build pdfgrep-feedstock with variant osx_64_ directly (without se
 [feature.build.tasks."inspect-osx_64_"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_.yaml"
 description = "List contents of pdfgrep-feedstock packages built for variant osx_64_"
+[feature.build.tasks."build-osx_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_.yaml"
+description = "Build pdfgrep-feedstock with variant osx_arm64_ directly (without setup scripts)"
+[feature.build.tasks."debug-osx_arm64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/osx_arm64_.yaml"
+description = "Build pdfgrep-feedstock with variant osx_arm64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-osx_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_.yaml"
+description = "List contents of pdfgrep-feedstock packages built for variant osx_arm64_"
 
 [environments]
 build = ["build"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,19 +1,18 @@
 schema_version: 1
 
 context:
-  name: pdfgrep
   version: 2.2.0
 
 package:
-  name: ${{ name|lower }}
+  name: pdfgrep
   version: ${{ version }}
 
 source:
-  url: https://pdfgrep.org/download/${{ name }}-${{ version }}.tar.gz
+  url: https://pdfgrep.org/download/pdfgrep-${{ version }}.tar.gz
   sha256: 0661e531e4c0ef097959aa1c9773796585db39c72c84a02ff87d2c3637c620cb
 
 build:
-  number: 8
+  number: 9
   skip: win
 
 requirements:


### PR DESCRIPTION
* Add linux-aarch64 and osx-arm64 natvie builds.
* Remove 'name' from context.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
